### PR TITLE
Fix usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Or install it yourself as:
 require 'ruby2_keywords'
 
 module YourModule
-  ruby2_keywords def oldstyle_keywords(options = {})
+  ruby2_keywords def delegating_method(*args)
+    other_method(*args)
   end
 end
 ```


### PR DESCRIPTION
The example warns in Ruby 2.7, and it isn't a case where you would
want to use ruby2_keywords.