### PR TITLE
Fix Ruby 2.5 incopatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ '3.0', 2.7, 2.6, head ]
+        ruby: [ '3.0', 2.7, 2.6, 2.5, head ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/lib/ruby2_keywords.rb
+++ b/lib/ruby2_keywords.rb
@@ -1,5 +1,5 @@
 class Module
-  unless private_method_defined?(:ruby2_keywords, true)
+  unless private_method_defined?(:ruby2_keywords)
     private
     # call-seq:
     #    ruby2_keywords(method_name, ...)


### PR DESCRIPTION
Resolves https://github.com/ruby/ruby2_keywords/issues/9

We don't really need that second optional argument, as its default value is just what we need, here:
https://ruby-doc.org/core-2.7.2/Module.html#method-i-private_method_defined-3F