### PR TITLE
Fix support for old rubies

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ ruby2_keywords :delegating_method
 Bug reports and pull requests are welcome on [GitHub] or
 [Ruby Issue Tracking System].
 
+## Development
+
+After checking out the repo, run `bundle install` to install dependencies.
+Then, run `bundle exec rake test` to run the tests.
+
+To test on older Ruby versions, you can use docker. E.g. to test on Ruby 2.0,
+use `docker-compose run ruby-2.0`.
+
 ## License
 
 The gem is available as open source under the terms of the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,57 @@
+version: '3.0'
+
+services:
+  ruby-2.0:
+    image: ruby:2.0
+    volumes:
+      - .:/app
+    command:
+      bash -c 'cd /app && bundle install && bundle exec rake test'
+  ruby-2.1:
+    image: ruby:2.1
+    volumes:
+      - .:/app
+    command:
+      bash -c 'cd /app && bundle install && bundle exec rake test'
+  ruby-2.2:
+    image: ruby:2.2
+    volumes:
+      - .:/app
+    command:
+      bash -c 'cd /app && bundle install && bundle exec rake test'
+  ruby-2.3:
+    image: ruby:2.3
+    volumes:
+      - .:/app
+    command:
+      bash -c 'cd /app && bundle install && bundle exec rake test'
+  ruby-2.4:
+    image: ruby:2.4
+    volumes:
+      - .:/app
+    command:
+      bash -c 'cd /app && bundle install && bundle exec rake test'
+  ruby-2.5:
+    image: ruby:2.5
+    volumes:
+      - .:/app
+    command:
+      bash -c 'cd /app && bundle install && bundle exec rake test'
+  ruby-2.6:
+    image: ruby:2.6
+    volumes:
+      - .:/app
+    command:
+      bash -c 'cd /app && bundle install && bundle exec rake test'
+  ruby-2.7:
+    image: ruby:2.7
+    volumes:
+      - .:/app
+    command:
+      bash -c 'cd /app && bundle install && bundle exec rake test'
+  ruby-3.0:
+    image: ruby:3.0
+    volumes:
+      - .:/app
+    command:
+      bash -c 'cd /app && bundle install && bundle exec rake test'

--- a/ruby2_keywords.gemspec
+++ b/ruby2_keywords.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.files = [
     "lib/ruby2_keywords.rb",
   ]
+  s.required_ruby_version = '>= 2.0.0'
   s.add_development_dependency 'test-unit', '>= 2.2'
   s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Hello there! 👋 

While adding `ruby2_keywords` to @datadog's [`ddtrace`](https://github.com/DataDog/dd-trace-rb) gem I discovered that it had a few incompatibilities with older rubies.

I went through every one of them, and replaced them with alternatives that work as far back as Ruby 2.0.
Out of curiosity, I tested 1.9 as well, and found there were further incompatibilities but I decided to stop at that point 🤣 .

Hopefully this is acceptable :)