### PR TITLE
Revert "Add TruffleRuby in CI"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,8 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ '3.0', 2.7, 2.6, 2.5, head, truffleruby ]
+        ruby: [ '3.0', 2.7, 2.6, 2.5, head ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        exclude:
-        - { os: windows-latest, ruby: truffleruby }
     runs-on: ${{ matrix.os }}
     steps:
     - name: git config


### PR DESCRIPTION
Reverts ruby/ruby2_keywords#11, because of test failures.